### PR TITLE
PTV-1860: Update Assembly ID to display refs.

### DIFF
--- a/kbase.yml
+++ b/kbase.yml
@@ -8,8 +8,8 @@ service-language:
     python
 
 module-version:
-    1.2.2
+    1.2.3
 
 owners:
-    [landml]
+    [dakota, landml]
 

--- a/lib/kb_ObjectInfo/CreateAssemblyReport.py
+++ b/lib/kb_ObjectInfo/CreateAssemblyReport.py
@@ -34,7 +34,7 @@ class CreateAssemblyReport:
         this_list = [['Assembly Name','Assembly ID', 'DNA size', 'GC content', 'Number contigs',
                 'FastA handle reference', 'MD5', 'Type', 'Taxon reference','Original filename']]
 
-        items = ['assembly_id', 'dna_size', 'gc_content', 'num_contigs',
+        items = ['dna_size', 'gc_content', 'num_contigs',
                 'fasta_handle_ref', 'md5', 'type', 'taxon_ref']
 
         # DataFileUtil guarantees that 'info' contains object_info:
@@ -137,4 +137,3 @@ class CreateAssemblyReport:
                 report_txt.close()
 
         return(header)
-

--- a/lib/kb_ObjectInfo/CreateAssemblyReport.py
+++ b/lib/kb_ObjectInfo/CreateAssemblyReport.py
@@ -10,11 +10,11 @@ class CreateAssemblyReport:
         self.callback_url = os.environ['SDK_CALLBACK_URL']
         self.dfu = DataFileUtil(self.callback_url)
 
-               
+
     def assembly_overview(self,obj_list):
         header = "OVERVIEW"
         this_list = [["Assembly Name","Type","Assembly Type"]]
-        
+
         for assembly in obj_list['data']:
             name = "Assembly Data Object"
             type_assem = ''
@@ -26,22 +26,22 @@ class CreateAssemblyReport:
                 type_assem = assembly['data']['type']
 
             this_list.extend([[name,object_type,type_assem]])
-        
+
         return (header,this_list)
-        
+
     def assembly_metadata(self,obj_list):
         header = "METADATA"
         this_list = [['Assembly Name','Assembly ID', 'DNA size', 'GC content', 'Number contigs',
                 'FastA handle reference', 'MD5', 'Type', 'Taxon reference','Original filename']]
-                
+
         items = ['assembly_id', 'dna_size', 'gc_content', 'num_contigs',
                 'fasta_handle_ref', 'md5', 'type', 'taxon_ref']
-                
+
         # DataFileUtil guarantees that 'info' contains object_info:
         # https://github.com/kbaseapps/DataFileUtil/blob/master/DataFileUtil.spec#L499-L506
         for assembly in obj_list['data']:
             name = assembly['info'][1]
-			ref = f"{assembly['info'][6]}/{assembly['info'][0]}/{assembly['info'][4]}"
+            ref = f"{assembly['info'][6]}/{assembly['info'][0]}/{assembly['info'][4]}"
 
             # Create the row for the one assembly
             assem_list = [name, ref]
@@ -55,18 +55,18 @@ class CreateAssemblyReport:
                 assem_list.append(assembly['data']['fasta_handle_info']['node_file_name'])
             else:
                 assem_list.append(" ")
-                
+
             # Add the row to the list that will be returned
             this_list.extend([assem_list])
-            
+
         return (header,this_list)
-        
+
     def assembly_dnabases(self,obj_list):
         header = "DNA Composition"
         this_list = [["Assembly Name","Total DNA Bases",
                         "A Count","A Percent","C Count","C Percent",
                         "G Count","G Percent","T Count","T Percent"]]
- 
+
         for assembly in obj_list['data']:
             name = "Assembly Data Object"
             if 'info' in assembly:
@@ -75,32 +75,32 @@ class CreateAssemblyReport:
             pct = 1.00
             if 'dna_size' in assembly['data']:
                 dna_size = assembly['data']['dna_size']
-            
+
             assem_list = [name,str(dna_size)]
             for base in ["A","C","G","T"]:
                 pct = round(100 * assembly['data']['base_counts'][base] / dna_size,2)
                 assem_list.append(str(assembly['data']['base_counts'][base]))
                 assem_list.append(str(pct))
-                
+
             this_list.extend([assem_list])
-            
+
         return(header,this_list)
-                
+
     def assembly_contigs(self,obj_list):
         header = "Contigs in the Assembly"
         this_list= [["Assembly Name","Contig Name","Length","GC content","Number of Ns","Contig ID","Description"]]
-        
+
         for assembly in obj_list['data']:
             name = "Assembly Data Object"
             if 'info' in assembly:
                 name = assembly['info'][1]
- 
+
             if 'contigs' in assembly['data']:
                 myContig = assembly['data']['contigs']
                 for ctg in myContig:
                     list = ['length', 'gc_content', 'Ncount', 'contig_id', 'description']
                     ctg_list = [name,ctg]
-                
+
                     for item in list:
                         if item in myContig[ctg]:
                             ctg_list.append(format(myContig[ctg][item]))
@@ -108,16 +108,16 @@ class CreateAssemblyReport:
                             ctg_list.append("")
 
                     this_list.append(ctg_list)
-                        
+
         return(header,this_list)
-        
-                        
+
+
     def assembly_dna(self,obj_list,scratch):
         header = "Contig FastA files found in the download files."
         fasta_list = []
         dna_string = ""
         cf = CreateFasta(self.config)
-        
+
         for assembly in obj_list['data']:
             name = "Assembly Data Object"
             input_ref = ''
@@ -127,7 +127,7 @@ class CreateAssemblyReport:
 
                 fasta_list = cf.get_assembly_sequence(input_ref)
                 report_path = os.path.join(scratch, name + '.fna')
-            
+
 #           Write the DNA string out to a Fasta file
                 report_txt = open(report_path, "w")
                 for dna_seq in fasta_list:
@@ -135,6 +135,6 @@ class CreateAssemblyReport:
                     report_txt.write(dna)
                     dna_string += dna
                 report_txt.close()
-            
+
         return(header)
-   
+

--- a/lib/kb_ObjectInfo/CreateAssemblyReport.py
+++ b/lib/kb_ObjectInfo/CreateAssemblyReport.py
@@ -34,17 +34,18 @@ class CreateAssemblyReport:
         this_list = [['Assembly Name','Assembly ID', 'DNA size', 'GC content', 'Number contigs',
                 'FastA handle reference', 'MD5', 'Type', 'Taxon reference','Original filename']]
                 
-        list = ['assembly_id', 'dna_size', 'gc_content', 'num_contigs',
+        items = ['assembly_id', 'dna_size', 'gc_content', 'num_contigs',
                 'fasta_handle_ref', 'md5', 'type', 'taxon_ref']
                 
+        # DataFileUtil guarantees that 'info' contains object_info:
+        # https://github.com/kbaseapps/DataFileUtil/blob/master/DataFileUtil.spec#L499-L506
         for assembly in obj_list['data']:
-            name = "Assembly Data Object"
-            if 'info' in assembly:
-                name = assembly['info'][1]
+            name = assembly['info'][1]
+			ref = f"{assembly['info'][6]}/{assembly['info'][0]}/{assembly['info'][4]}"
 
             # Create the row for the one assembly
-            assem_list = [name]
-            for item in list:
+            assem_list = [name, ref]
+            for item in items:
                 if item in assembly['data']:
                     assem_list.append(str(assembly['data'][item]))
                 else:

--- a/test/kb_ObjectInfo_test.py
+++ b/test/kb_ObjectInfo_test.py
@@ -82,7 +82,7 @@ class kb_ObjectInfoTest(unittest.TestCase):
                                                     "generate_ids_if_needed": 1,
                                                     "generate_missing_genes": 1
                                                     })['genome_ref']
-                                                    
+
 #       Prepare the Genome from gbff File
         cls.genbank_file_name = 'Carsonella_ruddii_HT_isolate_Thao2000.gbff'
 #       Set the path to file in scratch
@@ -251,9 +251,9 @@ class kb_ObjectInfoTest(unittest.TestCase):
         self.assertIn('report_name', ret[0])
         self.assertIn('report_ref', ret[0])
         pass
-        
-    def mytest_assembly_set(self):
-        assemblyset_ref = '69870/28/2'
+
+    def test_assembly_set(self):
+        assemblyset_ref = '72131/16/1'
         ret = self.getImpl().assemblyset_report(self.getContext(),
                                                       {'workspace_name': self.ws_info[1],
                                                        'input_ref': assemblyset_ref,
@@ -264,7 +264,7 @@ class kb_ObjectInfoTest(unittest.TestCase):
         self.assertIn('report_name', ret[0])
         self.assertIn('report_ref', ret[0])
         pass
-        
+
     def mytest_genome_protein_list(self):
         genome_ref = self.genome_ref
         genome_ref = '40843/4/1'
@@ -281,7 +281,7 @@ class kb_ObjectInfoTest(unittest.TestCase):
         self.assertIn('report_name', ret[0])
         self.assertIn('report_ref', ret[0])
         pass
-        
+
     def mytest_genome_protein_fasta(self):
         ret = self.getImpl().genome_report(self.getContext(),
                                            {'workspace_name': self.ws_info[1],
@@ -394,7 +394,7 @@ class kb_ObjectInfoTest(unittest.TestCase):
         self.assertIn('report_name', ret[0])
         self.assertIn('report_ref', ret[0])
         pass
-      
+
     def mytest_sequenceSet(self):
         featset_ref = '27092/23/1'
         ret = self.getImpl().featseq_report(self.getContext(),
@@ -405,7 +405,7 @@ class kb_ObjectInfoTest(unittest.TestCase):
         self.assertIn('report_name', ret[0])
         self.assertIn('report_ref', ret[0])
         pass
-    
+
     def mytest_ProtComp(self):
         protcomp_ref = '29939/15/1'
         ret = self.getImpl().protcomp_report(self.getContext(),
@@ -428,7 +428,7 @@ class kb_ObjectInfoTest(unittest.TestCase):
         self.assertIn('report_name', ret[0])
         self.assertIn('report_ref', ret[0])
         pass
-        
+
     def mytest_MSA(self):
         msa_ref = '70362/27/1'
         ret = self.getImpl().msa_report(self.getContext(),


### PR DESCRIPTION
Previously the Assembly ID column was displaying names instead of refs.

The names can be used to determine the ref by using the dataview page, but this could be tedious for sets with many assemblies and also is not the original intention of the app.

It is possible that this bug appeared as a result of some fixes to the narrative interface to refer to objects by name, where another app was relying on the object being referred to by its ref in the narrative interface. New documentation may be needed to direct app developers to access refs in a manner that does not depend on the implementation details of the narrative interface.